### PR TITLE
Create boolean operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ bsynth
 blender-3.3.1-linux-x64
 */__pycache__
 *.pyc
+
+build
+*.egg-info

--- a/blendersynth/blender/boolean.py
+++ b/blendersynth/blender/boolean.py
@@ -1,0 +1,31 @@
+import blendersynth as bsyn
+
+
+def _apply_boolean(
+    *meshes: bsyn.Mesh, operation: str = "UNION", hide_others: bool = True
+) -> bsyn.Mesh:
+    target, *others = meshes
+    for other in others:
+        target.add_child(other)
+
+        modifier = target.obj.modifiers.new(type="BOOLEAN", name="bool")
+        modifier.object = other.obj
+        modifier.operation = operation
+
+        bsyn.ops.object.modifier_apply(modifier="bool")
+        if hide_others:
+            other.obj.hide_render = True
+            other.obj.hide_set(True)
+    return target
+
+
+def union(*meshes: bsyn.Mesh, hide_others=True):
+    return _apply_boolean(*meshes, operation="UNION", hide_others=hide_others)
+
+
+def difference(*meshes: bsyn.Mesh, hide_others=True):
+    return _apply_boolean(*meshes, operation="DIFFERENCE", hide_others=hide_others)
+
+
+def intersect(*meshes: bsyn.Mesh, hide_others=True):
+    return _apply_boolean(*meshes, operation="INTERSECT", hide_others=hide_others)

--- a/blendersynth/blender/boolean.py
+++ b/blendersynth/blender/boolean.py
@@ -1,10 +1,14 @@
-import blendersynth as bsyn
+"""Functions for boolean operations of meshes"""
+import bpy
+from ..utils import types
 
 
 def _apply_boolean(
-    *meshes: bsyn.Mesh, operation: str = "UNION", hide_others: bool = True
-) -> bsyn.Mesh:
-    target, *others = meshes
+    target: types.Mesh,
+    *others: types.Mesh,
+    operation: str = "UNION",
+    hide_others: bool = True
+) -> types.Mesh:
     for other in others:
         target.add_child(other)
 
@@ -12,20 +16,40 @@ def _apply_boolean(
         modifier.object = other.obj
         modifier.operation = operation
 
-        bsyn.ops.object.modifier_apply(modifier="bool")
+        bpy.ops.object.modifier_apply(modifier="bool")
         if hide_others:
             other.obj.hide_render = True
             other.obj.hide_set(True)
     return target
 
 
-def union(*meshes: bsyn.Mesh, hide_others=True):
-    return _apply_boolean(*meshes, operation="UNION", hide_others=hide_others)
+def union(target: types.Mesh, *others: types.Mesh, hide_others=True) -> types.Mesh:
+    """Apply the union boolean modifier to a collection of meshes.
+
+    :param target: The target Mesh: this is returned by the function
+    :param others: Other Meshes to union with `target`
+    :param hide_others: If True, hide all Meshes in the `others` list"""
+    return _apply_boolean(target, *others, operation="UNION", hide_others=hide_others)
 
 
-def difference(*meshes: bsyn.Mesh, hide_others=True):
-    return _apply_boolean(*meshes, operation="DIFFERENCE", hide_others=hide_others)
+def difference(target: types.Mesh, *others: types.Mesh, hide_others=True) -> types.Mesh:
+    """Apply the difference boolean modifier to a collection of meshes.
+
+    :param target: The target Mesh: this is returned by the function
+    :param others: Other Meshes to subtract from `target`
+    :param hide_others: If True, hide all Meshes in the `others` list"""
+
+    return _apply_boolean(
+        target, *others, operation="DIFFERENCE", hide_others=hide_others
+    )
 
 
-def intersect(*meshes: bsyn.Mesh, hide_others=True):
-    return _apply_boolean(*meshes, operation="INTERSECT", hide_others=hide_others)
+def intersect(target: types.Mesh, *others: types.Mesh, hide_others=True) -> types.Mesh:
+    """Apply the intersect boolean modifier to a collection of meshes.
+
+    :param target: The target Mesh: this is returned by the function
+    :param others: Other Meshes to intersect with `target`
+    :param hide_others: If True, hide all Meshes in the `others` list"""
+    return _apply_boolean(
+        target, *others, operation="INTERSECT", hide_others=hide_others
+    )


### PR DESCRIPTION
Created the union, intersect, and difference boolean operators for meshes. Two questions to address:

- This currently only works with `bsyn.Mesh` - should it work with `bpy.types.Object` as well?
- The functions all take in a list of meshes, without explictly declaring a "target". I think this works well for `union`, but is perhaps not clear for `difference`. *But* I think all three methods should have the same signature. What is the ideal signature?