### PR TITLE
Add UTF-8 to subprocess.run, avoids cp1251 stdout encoding error on Windows

### DIFF
--- a/blendersynth/utils/blender_setup/check_blender_install.py
+++ b/blendersynth/utils/blender_setup/check_blender_install.py
@@ -36,6 +36,7 @@ def setup_blender_stubs(blender_path):
         [blender_path, "--background", "--python-expr", script_code],
         capture_output=True,
         text=True,
+        encoding='UTF-8'
     )
 
     for line in result.stdout.split("\n"):


### PR DESCRIPTION
Not having this seems to present problems, at least for me on Windows 11 & Python 3.12. The stdout by default in Python is CP1251 encoded and Blender outputs some character that it can't map properly and it crashes